### PR TITLE
fix: correct po files format

### DIFF
--- a/src/POHandler.cpp
+++ b/src/POHandler.cpp
@@ -805,9 +805,9 @@ void CPOHandler::WritePOEntry(const CPOEntry &currEntry)
     {
       WriteLF();
       if (id-m_previd == 2)
-        m_strOutBuffer += "#empty string with id "  + g_CharsetUtils.IntToStr(id-1) + "\n";
+        m_strOutBuffer += "# empty string with id "  + g_CharsetUtils.IntToStr(id-1) + "\n";
       if (id-m_previd > 2)
-        m_strOutBuffer += "#empty strings from id " + g_CharsetUtils.IntToStr(m_previd+1) + " to " + g_CharsetUtils.IntToStr(id-1) + "\n";
+        m_strOutBuffer += "# empty strings from id " + g_CharsetUtils.IntToStr(m_previd+1) + " to " + g_CharsetUtils.IntToStr(id-1) + "\n";
     }
     WriteMultilineComment(currEntry.interlineComm, "#");
     m_previd =id;


### PR DESCRIPTION
This is the syntax of po files (https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html).
```
white-space
#  translator-comments
#. extracted-comments
#: reference…
#, flag…
#| msgid previous-untranslated-string
msgid untranslated-string
msgstr translated-string
```

So there has to be a white space after `#` (unless it would be an extracted comment or a reference).